### PR TITLE
elemToRemove may be undefined

### DIFF
--- a/ctk-tooltip.js
+++ b/ctk-tooltip.js
@@ -13,9 +13,12 @@ export default {
           $tooltip.style.top = $tooltipDimension.top - 30 + 'px'
           document.body.appendChild($tooltip)
         })
+
         el.addEventListener('mouseleave', function () {
           var elemToRemove = document.getElementById('CtkTooltip')
-          elemToRemove.parentNode.removeChild(elemToRemove)
+          if (elemToRemove && elemToRemove.parentNode) {
+            elemToRemove.parentNode.removeChild(elemToRemove)
+          }
         })
       }
     })


### PR DESCRIPTION
Fix the following issue from Rollbar:

```
TypeError: Impossible d’obtenir la propriété « parentNode » d’une référence null ou non définie
1
File "webpack:///./node_modules/vue-ctk-tooltip/ctk-tooltip.js" line 18 col 1 in install
elemToRemove.parentNode.removeChild(elemToRemove)
```